### PR TITLE
Bump dependencies for 4.6.0

### DIFF
--- a/ubuntu/debian/control
+++ b/ubuntu/debian/control
@@ -17,13 +17,13 @@ Build-Depends: cmake,
                libignition-gui4-dev,
                libignition-math6-dev (>= 6.6.0),
                libignition-math6-eigen3-dev (>= 6.6.0),
-               libignition-msgs6-dev,
+               libignition-msgs6-dev (>= 6.4.0),
                libignition-plugin-dev,
                libignition-physics3-dev (>= 3.1.0),
                libignition-sensors4-dev,
                libignition-rendering4-dev (>= 4.1.0),
                libignition-transport9-log-dev,
-               libsdformat10-dev
+               libsdformat10-dev (>= 10.3.0)
 Vcs-Browser: https://github.com/ignition-release/ign-gazebo4-release
 Vcs-Git: https://github.com/ignition-release/ign-gazebo4-release
 Homepage: http://ignitionrobotics.org/
@@ -67,13 +67,13 @@ Depends: libtinyxml2-dev,
          libignition-gui4-dev,
          libignition-math6-dev (>= 6.6.0),
          libignition-math6-eigen3-dev (>= 6.6.0),
-         libignition-msgs6-dev,
+         libignition-msgs6-dev (>= 6.4.0),
          libignition-plugin-dev,
          libignition-physics3-dev (>= 3.1.0),
          libignition-sensors4-dev,
          libignition-rendering4-dev (>= 4.1.0),
          libignition-transport9-log-dev,
-         libsdformat10-dev,
+         libsdformat10-dev (>= 10.3.0),
          libignition-gazebo4 (= ${binary:Version}),
          libignition-gazebo4-plugins (= ${binary:Version}),
          ${misc:Depends}


### PR DESCRIPTION
Goes with https://github.com/ignitionrobotics/ign-gazebo/pull/660