### PR TITLE
Install *.yaml and *.rb in -dev package

### DIFF
--- a/ubuntu/debian/libignition-gazebo-dev.install
+++ b/ubuntu/debian/libignition-gazebo-dev.install
@@ -3,5 +3,5 @@ usr/lib/*/*.so
 usr/lib/*/pkgconfig/*.pc
 usr/lib/*/cmake/ignition-gazebo*/*
 usr/share/ignition/ignition-gazebo[0-99]/ignition-gazebo[0-99].tag.xml
-usr/share/ignition/gazebo[0-99].yaml
-usr/lib/ruby/ignition/cmdgazebo[0-99].rb
+usr/share/ignition/*.yaml
+usr/lib/ruby/ignition/*.rb


### PR DESCRIPTION
Last debbuild jobs were unstable:

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ign-gazebo4-debbuilder&build=248)](https://build.osrfoundation.org/job/ign-gazebo4-debbuilder/248/) https://build.osrfoundation.org/job/ign-gazebo4-debbuilder/248/

~~~
dh_missing: warning: usr/share/ignition/model4.yaml exists in debian/tmp but is not installed to anywhere
dh_missing: warning: usr/lib/ruby/ignition/cmdmodel4.rb exists in debian/tmp but is not installed to anywhere
~~~

This ports the fix made in https://github.com/ignition-release/ign-gazebo3-release/pull/11 (see https://github.com/ignition-release/ign-gazebo3-release/commit/51cf703372dd8f3b44244a7cc99cd03625c61379#diff-482958f3238bbb3dfa210a5c9908950efbc7455e059e6114850758c6d6c5e70c).